### PR TITLE
fix: add crossOrigin configuration to video examples to prevent WebGL SecurityError

### DIFF
--- a/public/3.55/src/game objects/video/play video.js
+++ b/public/3.55/src/game objects/video/play video.js
@@ -14,7 +14,8 @@ var game = new Phaser.Game(config);
 
 function preload ()
 {
-        this.load.setBaseURL('https://cdn.phaserfiles.com/v355');
+    this.load.setCORS('anonymous');
+    this.load.setBaseURL('https://cdn.phaserfiles.com/v355');
     this.load.video('wormhole', 'assets/video/wormhole.mp4', 'loadeddata', false, true);
 }
 

--- a/public/3.86/src/game objects/video/change video source.js
+++ b/public/3.86/src/game objects/video/change video source.js
@@ -10,6 +10,7 @@ class Example extends Phaser.Scene
 
     preload ()
     {
+        this.load.setCORS('anonymous');
         this.load.setBaseURL('https://cdn.phaserfiles.com/v385');
         this.load.video('mountains', 'assets/video/mountains.mp4', true);
         this.load.video('pumpkins', 'assets/video/pumpkins.mp4', true);

--- a/public/3.86/src/game objects/video/get first video frame.js
+++ b/public/3.86/src/game objects/video/get first video frame.js
@@ -7,6 +7,7 @@ class Example extends Phaser.Scene
 
     preload ()
     {
+        this.load.setCORS('anonymous');
         this.load.setBaseURL('https://cdn.phaserfiles.com/v385');
         this.load.video('spaceace', 'assets/video/spaceace.mp4');
         this.load.image('play', 'assets/ui/play-button.png');

--- a/public/3.86/src/game objects/video/loop video.js
+++ b/public/3.86/src/game objects/video/loop video.js
@@ -7,6 +7,7 @@ class Example extends Phaser.Scene
 
     preload ()
     {
+        this.load.setCORS('anonymous');
         this.load.setBaseURL('https://cdn.phaserfiles.com/v385');
         this.load.image('bg', 'assets/skies/space3.png');
         this.load.video('astronaut', 'assets/video/astronaut.webm', true);

--- a/public/3.86/src/game objects/video/multiple video instances.js
+++ b/public/3.86/src/game objects/video/multiple video instances.js
@@ -7,6 +7,7 @@ class Example extends Phaser.Scene
 
     preload ()
     {
+        this.load.setCORS('anonymous');
         this.load.setBaseURL('https://cdn.phaserfiles.com/v385');
         this.load.video('mountains', 'assets/video/mountains.mp4', true);
     }

--- a/public/3.86/src/game objects/video/multiple videos.js
+++ b/public/3.86/src/game objects/video/multiple videos.js
@@ -7,6 +7,7 @@ class Example extends Phaser.Scene
 
     preload ()
     {
+        this.load.setCORS('anonymous');
         this.load.setBaseURL('https://cdn.phaserfiles.com/v385');
         this.load.video('fireworks', 'assets/video/fireworks.mp4', true);
         this.load.video('pumpkins', 'assets/video/pumpkins.mp4', true);

--- a/public/3.86/src/game objects/video/on complete event.js
+++ b/public/3.86/src/game objects/video/on complete event.js
@@ -7,6 +7,7 @@ class Example extends Phaser.Scene
 
     preload ()
     {
+        this.load.setCORS('anonymous');
         this.load.setBaseURL('https://cdn.phaserfiles.com/v385');
         this.load.video('flight', 'assets/video/endless-flight.mp4', true);
     }

--- a/public/3.86/src/game objects/video/play video.js
+++ b/public/3.86/src/game objects/video/play video.js
@@ -7,6 +7,7 @@ class Example extends Phaser.Scene
 
     preload ()
     {
+        this.load.setCORS('anonymous');
         this.load.setBaseURL('https://cdn.phaserfiles.com/v385');
         this.load.video('spaceace', 'assets/video/spaceace.mp4');
     }

--- a/public/3.86/src/game objects/video/stream video from webcam.js
+++ b/public/3.86/src/game objects/video/stream video from webcam.js
@@ -7,6 +7,7 @@ class Example extends Phaser.Scene
 
     preload ()
     {
+        this.load.setCORS('anonymous');
         this.load.setBaseURL('https://cdn.phaserfiles.com/v385');
         this.load.image('bg', 'assets/pics/purple-bars.jpg');
         this.load.image('monitor', 'assets/pics/commodore1084.png');

--- a/public/3.86/src/game objects/video/stream video from webcam.js
+++ b/public/3.86/src/game objects/video/stream video from webcam.js
@@ -7,7 +7,6 @@ class Example extends Phaser.Scene
 
     preload ()
     {
-        this.load.setCORS('anonymous');
         this.load.setBaseURL('https://cdn.phaserfiles.com/v385');
         this.load.image('bg', 'assets/pics/purple-bars.jpg');
         this.load.image('monitor', 'assets/pics/commodore1084.png');

--- a/public/3.86/src/game objects/video/transparent video.js
+++ b/public/3.86/src/game objects/video/transparent video.js
@@ -11,6 +11,7 @@ class Example extends Phaser.Scene
 
     preload ()
     {
+        this.load.setCORS('anonymous');
         this.load.setBaseURL('https://cdn.phaserfiles.com/v385');
         this.load.video('robot', 'assets/video/robot-dance.webm');
         this.load.audio('tune', 'assets/audio/aquakitty-kittyrock.m4a');

--- a/public/3.86/src/game objects/video/video as shader texture.js
+++ b/public/3.86/src/game objects/video/video as shader texture.js
@@ -7,6 +7,7 @@ class Example extends Phaser.Scene
 
     preload ()
     {
+        this.load.setCORS('anonymous');
         this.load.setBaseURL('https://cdn.phaserfiles.com/v385');
         this.load.video('trainSequence', 'assets/video/train512x256.mp4', true);
         this.load.image('noise', 'assets/tests/rgba-noise-medium.png');

--- a/public/3.86/src/game objects/video/video controls.js
+++ b/public/3.86/src/game objects/video/video controls.js
@@ -15,6 +15,7 @@ class Example extends Phaser.Scene
 
     preload ()
     {
+        this.load.setCORS('anonymous');
         this.load.setBaseURL('https://cdn.phaserfiles.com/v385');
         this.load.atlas('ui', 'assets/ui/dark-ui.png', 'assets/ui/dark-ui.json');
         this.load.video('fireworks', 'assets/video/fireworks.mp4', true);

--- a/public/3.86/src/game objects/video/video set current time.js
+++ b/public/3.86/src/game objects/video/video set current time.js
@@ -13,6 +13,7 @@ class Example extends Phaser.Scene
 
     preload ()
     {
+        this.load.setCORS('anonymous');
         this.load.setBaseURL('https://cdn.phaserfiles.com/v385');
         this.load.video('spaceace', 'assets/video/spaceace.mp4', true);
         this.load.atlas('ui', 'assets/ui/dark-ui.png', 'assets/ui/dark-ui.json');

--- a/public/3.86/src/game objects/video/video snapshot area.js
+++ b/public/3.86/src/game objects/video/video snapshot area.js
@@ -10,6 +10,7 @@ class Example extends Phaser.Scene
 
     preload ()
     {
+        this.load.setCORS('anonymous');
         this.load.setBaseURL('https://cdn.phaserfiles.com/v385');
         this.load.video('spaceace', 'assets/video/spaceace.mp4', true);
         this.load.atlas('ui', 'assets/ui/dark-ui.png', 'assets/ui/dark-ui.json');

--- a/public/3.86/src/game objects/video/video snapshot.js
+++ b/public/3.86/src/game objects/video/video snapshot.js
@@ -10,6 +10,7 @@ class Example extends Phaser.Scene
 
     preload ()
     {
+        this.load.setCORS('anonymous');
         this.load.setBaseURL('https://cdn.phaserfiles.com/v385');
         this.load.video('spaceace', 'assets/video/spaceace.mp4', true);
         this.load.atlas('ui', 'assets/ui/dark-ui.png', 'assets/ui/dark-ui.json');

--- a/public/3.86/src/game objects/video/video to sprites.js
+++ b/public/3.86/src/game objects/video/video to sprites.js
@@ -10,6 +10,7 @@ class Example extends Phaser.Scene
 
     preload ()
     {
+        this.load.setCORS('anonymous');
         this.load.setBaseURL('https://cdn.phaserfiles.com/v385');
         this.load.video('skeletonSequence', 'assets/video/skeleton.webm', true);
         this.load.audio('tune', 'assets/audio/mag-overkill.m4a');

--- a/public/3.86/src/game objects/video/video transition.js
+++ b/public/3.86/src/game objects/video/video transition.js
@@ -13,6 +13,7 @@ class Example extends Phaser.Scene
 
     preload ()
     {
+        this.load.setCORS('anonymous');
         this.load.setBaseURL('https://cdn.phaserfiles.com/v385');
         this.load.video('fireworks', 'assets/video/fireworks.mp4', true);
         this.load.video('transition', 'assets/video/colorful-smoke-transition.webm', true);


### PR DESCRIPTION
## Background

When video assets are served from a different origin, the examples may load successfully and play audio, but the video image fails to render in WebGL. Browsers then raise a `SecurityError` similar to:

```
Failed to execute 'texImage2D' on 'WebGLRenderingContext':
The video element contains cross-origin data, and may not be loaded.
```

This occurs because WebGL cannot upload video frames as textures unless the video element is initialized with a `crossOrigin` attribute and the resource is CORS-enabled.

## Purpose of This Change

Adding `this.load.setCORS('anonymous')` ensures that the video element is created with the correct cross-origin configuration. This prevents the WebGL `SecurityError` and allows video frames to render correctly when assets are hosted on different origins (local development, CDN setups, etc.).

## Impact

- No breaking changes.
- No effect on same-origin setups.
- Improves reliability of all video examples in common developer environments.

If further changes or adjustments are preferred, I can update the PR accordingly.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `this.load.setCORS('anonymous')` to video example preloaders so cross-origin videos render correctly in WebGL.
> 
> - **Video examples**: Configure anonymous CORS for video assets
>   - `public/3.86/src/game objects/video/*`:
>     - Added `this.load.setCORS('anonymous')` in `preload()` across examples (`change video source`, `get first video frame`, `loop video`, `multiple video instances`, `multiple videos`, `on complete event`, `play video`, `stream video from webcam`, `transparent video`, `video as shader texture`, `video controls`, `video set current time`, `video snapshot area`, `video snapshot`, `video to sprites`, `video transition`).
>   - `public/3.55/src/game objects/video/play video.js`:
>     - Added `this.load.setCORS('anonymous')` before setting `BaseURL`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9b6ead769b2bc384fa79671d62e6fc863c162387. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->